### PR TITLE
fixing temp offset for LPS25

### DIFF
--- a/Adafruit_LPS22.cpp
+++ b/Adafruit_LPS22.cpp
@@ -19,6 +19,7 @@ bool Adafruit_LPS22::_init(int32_t sensor_id) {
   _sensorid_temp = sensor_id + 1;
 
   temp_scaling = 100;
+  temp_offset = 0;
 
   ctrl1_reg = new Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LPS22_CTRL_REG1, 1);

--- a/Adafruit_LPS25.cpp
+++ b/Adafruit_LPS25.cpp
@@ -19,6 +19,7 @@ bool Adafruit_LPS25::_init(int32_t sensor_id) {
   _sensorid_temp = sensor_id + 1;
 
   temp_scaling = 480;
+  temp_offset = 42.5;
   inc_spi_flag = 0x40;
 
   ctrl1_reg = new Adafruit_BusIO_Register(

--- a/Adafruit_LPS2X.cpp
+++ b/Adafruit_LPS2X.cpp
@@ -200,7 +200,7 @@ void Adafruit_LPS2X::_read(void) {
   if (raw_temp & 0x8000) {
     raw_temp = raw_temp - 0xFFFF;
   }
-  _temp = raw_temp / temp_scaling;
+  _temp = (raw_temp / temp_scaling) + temp_offset;
 
   if (raw_pressure & 0x800000) {
     raw_pressure = raw_pressure - 0xFFFFFF;

--- a/Adafruit_LPS2X.h
+++ b/Adafruit_LPS2X.h
@@ -144,6 +144,7 @@ protected:
   uint16_t _sensorid_pressure, ///< ID number for pressure
       _sensorid_temp;          ///< ID number for temperature
   float temp_scaling = 1;      ///< Different chips have different scalings
+  float temp_offset = 1;       ///< Different chips have different offsets
   uint8_t inc_spi_flag =
       0; ///< If this chip has a bitflag for incrementing SPI registers
 


### PR DESCRIPTION
The temp offset for the LPS25 got misplaced in the refactor and it was returning below freezing temps while I'm roasting.