### PR TITLE
Fix One Shot Mode

### DIFF
--- a/Adafruit_LPS22.cpp
+++ b/Adafruit_LPS22.cpp
@@ -53,6 +53,8 @@ void Adafruit_LPS22::setDataRate(lps22_rate_t new_data_rate) {
       Adafruit_BusIO_RegisterBits(ctrl1_reg, 3, 4);
 
   data_rate.write((uint8_t)new_data_rate);
+
+  isOneShot = (new_data_rate == LPS22_RATE_ONE_SHOT) ? true : false;
 }
 
 /**

--- a/Adafruit_LPS25.cpp
+++ b/Adafruit_LPS25.cpp
@@ -54,6 +54,8 @@ void Adafruit_LPS25::setDataRate(lps25_rate_t new_data_rate) {
       Adafruit_BusIO_RegisterBits(&ctrl1, 3, 4);
 
   data_rate.write((uint8_t)new_data_rate);
+
+  isOneShot = (new_data_rate == LPS22_RATE_ONE_SHOT) ? true : false;
 }
 
 /**

--- a/Adafruit_LPS2X.cpp
+++ b/Adafruit_LPS2X.cpp
@@ -175,7 +175,6 @@ void Adafruit_LPS2X::_read(void) {
 
   // for one-shot mode, must manually initiate a reading
   if (isOneShot) {
-    Serial.println("one shot");
     Adafruit_BusIO_RegisterBits oneshot_bit =
         Adafruit_BusIO_RegisterBits(ctrl2_reg, 1, 0);
     oneshot_bit.write(1); // initiate reading

--- a/Adafruit_LPS2X.cpp
+++ b/Adafruit_LPS2X.cpp
@@ -173,6 +173,16 @@ void Adafruit_LPS2X::_read(void) {
     temp_addr |= inc_spi_flag;
   }
 
+  // for one-shot mode, must manually initiate a reading
+  if (isOneShot) {
+    Serial.println("one shot");
+    Adafruit_BusIO_RegisterBits oneshot_bit =
+        Adafruit_BusIO_RegisterBits(ctrl2_reg, 1, 0);
+    oneshot_bit.write(1); // initiate reading
+    while (oneshot_bit.read())
+      delay(1); // wait for completon
+  }
+
   Adafruit_BusIO_Register pressure_data = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, pressure_addr, 3);
 

--- a/Adafruit_LPS2X.cpp
+++ b/Adafruit_LPS2X.cpp
@@ -179,7 +179,7 @@ void Adafruit_LPS2X::_read(void) {
         Adafruit_BusIO_RegisterBits(ctrl2_reg, 1, 0);
     oneshot_bit.write(1); // initiate reading
     while (oneshot_bit.read())
-      delay(1); // wait for completon
+      delay(1); // wait for completion
   }
 
   Adafruit_BusIO_Register pressure_data = Adafruit_BusIO_Register(

--- a/Adafruit_LPS2X.h
+++ b/Adafruit_LPS2X.h
@@ -147,6 +147,7 @@ protected:
   float temp_offset = 1;       ///< Different chips have different offsets
   uint8_t inc_spi_flag =
       0; ///< If this chip has a bitflag for incrementing SPI registers
+  bool isOneShot = false; ///< true if data rate is one-shot
 
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface


### PR DESCRIPTION
For #4.

For one-shot mode, the sensor conversion must be manually triggered and then polled for completion.

![image](https://user-images.githubusercontent.com/8755041/166604516-121f0c4f-7bee-40d2-a642-bc7e66842ab4.png)

Tested with a QT Py M0 and both LPS22 and LPS25 using sketch from issue thread (mod'd for LPS25 as needed).

Here's LPS25 example:
![Screenshot from 2022-05-03 16-57-54](https://user-images.githubusercontent.com/8755041/166604685-4ad46e76-ebc8-4abd-adee-e3a5a1564c39.png)



