### PR TITLE
Fix use of uninitialized variable

### DIFF
--- a/Adafruit_LPS2X.cpp
+++ b/Adafruit_LPS2X.cpp
@@ -193,7 +193,7 @@ void Adafruit_LPS2X::_read(void) {
   temp_data.read(buffer, 2);
   int16_t raw_temp;
 
-  raw_temp |= (int16_t)(buffer[1]);
+  raw_temp = (int16_t)(buffer[1]);
   raw_temp <<= 8;
   raw_temp |= (int16_t)(buffer[0]);
 


### PR DESCRIPTION
Pretty simple fix for a local variable in `Adafruit_LPS2X::_read()`.